### PR TITLE
Remove CodexScripter

### DIFF
--- a/Codices.sc
+++ b/Codices.sc
@@ -1,22 +1,13 @@
-CodexScripter : Codex {
-	initCodex {
-		modules.tagSynthDefs(this.class.name
-			++"_"++this.moduleSet++"_");
-
-		this.initScripter;
-	}
-
-	initScripter { }
-}
-
-CodexSections : CodexScripter {
+CodexSections : Codex {
 	var <order, <index = -1, <>wrap = false;
 	var freeFunctions;
 
-	initScripter {
+	initCodex {
 		order = this.arrange;
 		index = -1;
 		freeFunctions = [ ];
+
+		this.initSections;
 	}
 
 	initSections { }
@@ -83,14 +74,14 @@ CodexSections : CodexScripter {
 
 }
 
-CodexProxier : CodexScripter {
+CodexProxier : Codex {
 	var changes;
 
 	*makeTemplates { | templater |
 		templater.function("setup");
 	}
 
-	initScripter {
+	initCodex {
 		modules.setup;
 		this.initProxier;
 	}


### PR DESCRIPTION
The CodexScripter class is no longer necessary since its primary function was go back and redundantly tag (and add) all SynthDefs stored in the modules environment. This allowed for support for module scripts where multiple SynthDefs could be added in the same file. 

Because Codex now supports this behavior as of this [update](https://github.com/ianmacdougald/Codex/commit/59dd9073dcc011d0f8dabf6973be7ad9d96ab934) (without the redundant checking too), all former subclasses of CodexScripter can now inherit directly from Codex.

That is the change this PR makes.
