### PR TITLE
Replace tempo changes interface with TempoBusClock

### DIFF
--- a/Codices.quark
+++ b/Codices.quark
@@ -2,7 +2,7 @@
 name: "Codices", 
 summary: "Extensions for the Codex framework",
 author: "ianmacdougald", 
-version: "0.1.0", 
+version: "0.1.1", 
 copyright: "ianmacdougald", 
 schelp: "Overviews/Codices",
 dependencies: [],

--- a/Codices.sc
+++ b/Codices.sc
@@ -75,7 +75,6 @@ CodexSections : Codex {
 }
 
 CodexProxier : Codex {
-	var changes;
 
 	*makeTemplates { | templater |
 		templater.function("setup");
@@ -145,14 +144,13 @@ CodexProxier : Codex {
 
 	tempo_{ | newTempo |
 		this.clock !? { this.clock.tempo = newTempo };
-		try { this.proxySpace.use { changes.value } };
 	}
 
 	tempo {
 		if (this.clock.notNil) {
 			^this.clock.tempo;
 		} /* else */ {
-			"Failed to get tempo. No clock found.".warn;
+			// "Failed to get tempo. No clock found.".warn;
 			^nil;
 		};
 	}
@@ -163,12 +161,14 @@ CodexProxier : Codex {
 
 	quant { ^(this.proxySpace.quant ? 1) }
 
-	onTempoChange { | action |
-		changes = changes ? FunctionList.new;
-		changes.addFunc(action);
-	}
+	makeTempoClock { | tempo(1.0), beats, seconds |
+		var clock = this.clock;
 
-	clearChanges { changes = nil }
+		if (clock.isNil || clock.isKindOf(TempoBusClock).not) {
+			this.proxySpace.makeTempoClock(this.tempo ? 1.0, beats, seconds);
+			this.quant = this.clock.beatsPerBar;
+		};
+	}
 }
 
 CodexProxySections : CodexProxier {


### PR DESCRIPTION
It turns out there was already a class in the standard sclang library that does what I wanted to have been doing with the "onTempoChange" interface for CodexProxier.

So I removed that interface with a "makeTempoClock" method reminiscent of the ProxySpace equivalent, thus extending CodexProxier's duck typing relationship with ProxySpace.